### PR TITLE
Remove implicit declaration warning when compiling simple.c

### DIFF
--- a/docs/materials/htcondor/part1-ex7-compile.md
+++ b/docs/materials/htcondor/part1-ex7-compile.md
@@ -18,6 +18,8 @@ Here is a simple C program to try using (thanks, Alain Roy):
 
 ``` c
 #include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
One or both of two things has happened in EL8:
1. Newer gcc warns by default about implicit declarations for sleep and atoi (and other standard functions), or
2. Newer libC puts `sleep` and `atoi` in different libraries.

Either way, this small change makes gcc happy.

Example of current warnings:
```
simple.c: In function ‘main’:
simple.c:13:22: warning: implicit declaration of function ‘atoi’ [-Wimplicit-function-declaration]
         sleep_time = atoi(argv[1]);
                      ^~~~
simple.c:17:9: warning: implicit declaration of function ‘sleep’ [-Wimplicit-function-declaration]
         sleep(sleep_time);
         ^~~~~
```